### PR TITLE
Added rake tasks to easily switch development databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 .DS_Store
 .idea
 
+# Ignore database.yml configuration file
+/config/database.yml
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ gem "gmaps4rails"
 
 gem 'pg'
 
+group :development, :test do
+  gem 'sqlite3'
+end
+
 # Gems used only for assets and not required
 # in production environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    sqlite3 (1.3.7)
     subexec (0.2.2)
     systemu (2.5.2)
     therubyracer (0.11.3)
@@ -183,6 +184,7 @@ DEPENDENCIES
   pg
   rails (= 3.2.11)
   sass-rails (~> 3.2.3)
+  sqlite3
   therubyracer
   twitter-bootstrap-rails
   uglifier (>= 1.0.3)

--- a/config/database.postgres.yml
+++ b/config/database.postgres.yml
@@ -1,0 +1,55 @@
+# PostgreSQL. Versions 8.2 and up are supported.
+#
+# Install the pg driver:
+
+#   gem install pg
+# On Mac OS X with macports:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
+#
+development:
+  adapter: postgresql
+  encoding: unicode
+  host: localhost
+  database: rgmanager_development
+  pool: 5
+  username: rgmanager
+  password:
+  template: template0 # Required
+
+
+# Connect on a TCP socket. Omitted by default since the client uses a
+# domain socket that doesn't need configuration. Windows does not have
+# domain sockets, so uncomment these lines.
+#host: localhost
+#port: 5432
+
+# Schema search path. The server defaults to $user,public
+#schema_search_path: myapp,sharedapp,public
+
+# Minimum log levels, in increasing order:
+#   debug5, debug4, debug3, debug2, debug1,
+#   log, notice, warning, error, fatal, and panic
+# The server defaults to notice.
+#min_messages: warning
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  adapter: postgresql
+  encoding: unicode
+  host: localhost
+  database: rgmanager_test
+  pool: 5
+  username: rgmanager
+  password: 
+  template: template0 # Required
+
+

--- a/config/database.sqlite.yml
+++ b/config/database.sqlite.yml
@@ -17,9 +17,3 @@ test:
   database: db/test.sqlite3
   pool: 5
   timeout: 5000
-
-production:
-  adapter: sqlite3
-  database: db/production.sqlite3
-  pool: 5
-  timeout: 5000

--- a/lib/tasks/database_selection.rake
+++ b/lib/tasks/database_selection.rake
@@ -1,0 +1,21 @@
+namespace :db do
+  namespace :select do
+    desc "Select SQLite as the development database"
+    task :sqlite do
+      config_dir = File.join(Rails.root, 'config')
+      sqlite_yml_path = File.join(config_dir, 'database.sqlite.yml')
+      database_yml_path = File.join(config_dir, 'database.yml')
+      puts "Copying #{sqlite_yml_path} to #{database_yml_path}"
+      FileUtils.cp sqlite_yml_path, database_yml_path
+    end
+
+    desc "Select Postgres as the development database"
+    task :postgres do
+      config_dir = File.join(Rails.root, 'config')
+      postgres_yml_path = File.join(config_dir, 'database.postgres.yml')
+      database_yml_path = File.join(config_dir, 'database.yml')
+      puts "Copying #{postgres_yml_path} to #{database_yml_path}"
+      FileUtils.cp postgres_yml_path, database_yml_path
+    end
+  end
+end


### PR DESCRIPTION
### Re: the recent database configuration commits:

There are plenty of valid reasons to test the application locally with a test environment similar to the server's environment, and it's certainly a good idea to run the tests on Postgres before merging pull requests or deploying.

At the same time, some potential contributors have given up before getting the application to run successfully on their local machines.  At yesterday's RailsGirls meetup, I was asked to help three people set up a Postgres development database for this application.  Even with the new directions, none of them was successful, for a variety reasons having to do with the peculiarities of their local machines' configurations.

This commit is a suggestion about how to balance those two concerns.  In order to make it easy for newbie contributors to get started quickly, while also making it easy for more advanced developers to use Postgres, this commit changes the following:
- Adds two new database configuration files, database.postgres.yml and database.sqlite.yml, in order to maintain both Postgres and SQLite configuration options in the repository
- Adds two rake tasks that copy one or the other of the configurations above into database.yml (db:select:postgres and db:select:sqlite)
- Adds sqlite3 to the development and test groups in the Gemfile, so that it is available for development and testing (but not in production)
- Makes SQLite the default development and test database
- Adds database.yml to the .gitignore file, so that contributors' database selections don't get committed and affect others

Note what this would imply about the social structure of the project: people who are merging pull requests should be using Postgres and running the tests on the proposed changes before merging.
